### PR TITLE
Allow multi-column outputs in group UDF

### DIFF
--- a/abctools/abc_classes.py
+++ b/abctools/abc_classes.py
@@ -419,7 +419,8 @@ def apply_per_group_preserve_key(
     """
     Apply a user-defined function to each group of a DataFrame, preserving the key column.
     NOTE: This is surprisingly a bit tricky in polars, and a better solution is welcome.
-    Handles both DataFrame and scalar outputs from the user-defined function.
+    Handles both DataFrame and scalar outputs from the user-defined function
+    and allows the UDF to return multiple columns.
 
     Args:
         df (pl.DataFrame): The input DataFrame.
@@ -439,12 +440,6 @@ def apply_per_group_preserve_key(
         if not isinstance(result, pl.DataFrame):
             # Wrap scalar output in a DataFrame
             result = pl.DataFrame({result_column: [result]})
-
-        # Check that the result is a scalar because arrays dictionaries lists shouldn't be allowed
-        if result.shape[1] > 1:
-            raise ValueError(
-                "The user-defined function must return a scalar or a DataFrame with one column."
-            )
 
         # Add the key column to the result
         result = result.with_columns(pl.lit(part[key][0]).alias(key))

--- a/abctools/tests/test_apply_per_group.py
+++ b/abctools/tests/test_apply_per_group.py
@@ -1,0 +1,35 @@
+import polars as pl
+from abctools.abc_classes import apply_per_group_preserve_key
+
+
+def test_apply_per_group_multiple_columns():
+    df = pl.DataFrame({"group": ["a", "a", "b"], "x": [1, 2, 3]})
+
+    def udf(subdf: pl.DataFrame) -> pl.DataFrame:
+        return pl.DataFrame(
+            {
+                "x_sum": [subdf["x"].sum()],
+                "x_mean": [subdf["x"].mean()],
+            }
+        )
+
+    result = apply_per_group_preserve_key(df, key="group", user_udf=udf)
+
+    assert set(result.columns) == {"group", "x_sum", "x_mean"}
+    assert result.filter(pl.col("group") == "a")["x_sum"].item() == 3
+    assert result.filter(pl.col("group") == "b")["x_sum"].item() == 3
+
+
+def test_apply_per_group_scalar():
+    df = pl.DataFrame({"group": ["a", "a", "b"], "x": [1, 2, 3]})
+
+    def udf(subdf: pl.DataFrame) -> int:
+        return subdf["x"].sum()
+
+    result = apply_per_group_preserve_key(
+        df, key="group", user_udf=udf, result_column="total"
+    )
+
+    assert result.columns == ["group", "total"]
+    assert result.filter(pl.col("group") == "a")["total"].item() == 3
+    assert result.filter(pl.col("group") == "b")["total"].item() == 3


### PR DESCRIPTION
## Summary
- relax column count check in `apply_per_group_preserve_key`
- add unit tests for scalar and multi-column outputs

## Testing
- `pytest -q abctools/tests/test_apply_per_group.py` *(fails: ModuleNotFoundError: No module named 'polars')*

------
https://chatgpt.com/codex/tasks/task_e_6847a5119e848327aa6e920d01716d69